### PR TITLE
K8S version and TF instruction updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Oracle Container Engine for Kubernetes (OKE) is the [Oracle][uri-oracle]-managed
 
 > ⚠️ Kubeflow 1.5.0 is not compatible with Kubernetes version 1.22 and onwards. To install Kubeflow 1.5.0 or older, set the Kubernetes version of your OKE cluster to v1.21.5.
 
-> ⚠️ This guide explains how to install Kubeflow 1.7.0 on OKE using Kubernetes versions 1.25.6 and onwards running on Oracle Linux 8.
+> ⚠️ This guide explains how to install Kubeflow 1.7.0 on OKE using Kubernetes versions 1.27.2 and onwards running on Oracle Linux 8.
 
 > Note the following steps are for testing purposes. 
 
@@ -33,14 +33,14 @@ This guide uses the [Cloud Shell](https://docs.oracle.com/en-us/iaas/Content/API
 1. From the OCI Cloud Shell clone this repo.
 git clone https://github.com/oracle-devrel/kubeflow-oke.git
 
-1. Edit the module.tf file to set the compartment and tenancy ocid's, your home region and the region you want to deploy in review the other settings, especially the security settings around control plane access, bastions and operators
-consider the node pool setup and if you want to use the cluster autoscaler. 
+1. Edit the module.tf file to set the compartment and tenancy ocid's, your home region and the region you want to deploy in review the other settings, especially the security settings around control plane access, bastions and operators. If needed change the Kubernetes version to match the version supported by the Kubeflow version you are installing. Consider the node pool setup and if you want to use the cluster autoscaler. 
 
     Review the number of nodes in each node pool, in this example we are using three node pools.
    - system for running system processes in, e.g. prometheus and metrics server.
    - app for running actuall applications in, e.g. the kubeflow runtime.
    - processing for executing your actual analysis in, if you want this to auto scale set autoscale to be true and the max_node_pool_size to meet your needs.
 
+2. Edit the providers.tf file, replace the first provider region with the name of the region you want to create the OKE cluster in, replace the second provider region with the name of your home region (there are comments indicating which one to change to what).
 
 If you are running in the OCI cloud shell (recommended), then you're all good to go. If not, you will need to configure the terraform provider security credentials
 

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Copyright (c) 2023, Oracle and/or its affiliates.
+
+# The boot folume is setup on a 50gb FS, buf some ML / AI tools require a larger space to handle their images
+# The TF module lets you set the volume size but it still needs to be grown so do that here.
+sudo /usr/libexec/oci-growfs -y
 # Set it up to install on a reboot
 cat  <<EOF | sudo tee /etc/modules-load.d/99-istio-modules.conf
 # These modules need to be loaded on boot so that Istio (as required by

--- a/module.tf
+++ b/module.tf
@@ -31,7 +31,7 @@ module oke {
   control_plane_allowed_cidrs=["0.0.0.0/0"]
 
   # what version of kubernetes to instal, not all kubernrtes versions are supported so check in the OCI UI
-  kubernetes_version="v1.26.2"
+  kubernetes_version="v1.27.2"
 
   # The below is a 3 node pool setup, assuming that you have the mechanisms in kubeflow to setup affinity to target workloads to specific pools / processing types
   node_pools = {

--- a/provider.tf
+++ b/provider.tf
@@ -1,9 +1,11 @@
 provider "oci" {
    auth = "InstancePrincipal"
+   # Change this to be the region you want to deploy into
    region = "us-ashburn-1"
 }
 provider "oci" {
    auth = "InstancePrincipal"
+   # change this to be your home region
    region = "us-ashburn-1"
    alias  = "home"
 }


### PR DESCRIPTION
Updated to use K8S 1.27.2
Updates cloud-init to grow the root FS (allows for larger images often used in ML models) Updated instructions to update the provider.tf if needed (and highlighted change locations in the file)